### PR TITLE
🐛 fix: use a more generalized name to save the quota of GA and just b…

### DIFF
--- a/packages/docs/app/components/internal/TerminalCommandInstructor.tsx
+++ b/packages/docs/app/components/internal/TerminalCommandInstructor.tsx
@@ -45,7 +45,7 @@ export default function TerminalCommandInstructor({
   const copy = () => {
     navigator.clipboard.writeText(cliForTab(cliTab));
     setCopied(true);
-    track('copy_cli_command', { manager: cliTab, command: cli });
+    track('copy_cli_command', { category: cliTab, content: cli });
     setTimeout(() => setCopied(false), 1500);
   }
 


### PR DESCRIPTION
…eing more useful in many cases